### PR TITLE
Fix/pom version

### DIFF
--- a/.github/workflows/checkpackaging.yml
+++ b/.github/workflows/checkpackaging.yml
@@ -25,19 +25,19 @@ jobs:
           sudo apt-get install -y maven wget
       - name: Download and install jhighs
         run: |
-          if wget https://github.com/jessenagel/JHiGHS/releases/download/v1.0-SNAPSHOT/jhighs-1.0-SNAPSHOT.jar; then
+          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.0/jhighs-0.1.0.jar; then
             echo "Download successful"
-            ls -la jhighs-1.0-SNAPSHOT.jar
+            ls -la jhighs-0.1.0.jar
           else
             echo "Download failed"
             exit 1
           fi
-
+          
           mvn install:install-file \
-            -Dfile=jhighs-1.0-SNAPSHOT.jar \
-            -DgroupId=nl.jessenagel.jhighs \
+            -Dfile=jhighs-0.1.0.jar \
+            -DgroupId=nl.jessenagel.optimization \
             -DartifactId=jhighs \
-            -Dversion=1.0-SNAPSHOT \
+            -Dversion=0.1.0 \
             -Dpackaging=jar
 
       - name: Verify jhighs installation

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,19 +30,19 @@ jobs:
           sudo apt-get install -y maven wget
       - name: Download and install jhighs
         run: |
-          if wget https://github.com/jessenagel/JHiGHS/releases/download/v1.0-SNAPSHOT/jhighs-1.0-SNAPSHOT.jar; then
+          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.0/jhighs-0.1.0.jar; then
             echo "Download successful"
-            ls -la jhighs-1.0-SNAPSHOT.jar
+            ls -la jhighs-0.1.0.jar
           else
             echo "Download failed"
             exit 1
           fi
           
           mvn install:install-file \
-            -Dfile=jhighs-1.0-SNAPSHOT.jar \
-            -DgroupId=nl.jessenagel.jhighs \
+            -Dfile=jhighs-0.1.0.jar \
+            -DgroupId=nl.jessenagel.optimization \
             -DartifactId=jhighs \
-            -Dversion=1.0-SNAPSHOT \
+            -Dversion=0.1.0 \
             -Dpackaging=jar
 
       - name: Verify jhighs installation

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.jessenagel.optimization</groupId>
     <artifactId>orchestrate</artifactId>
-    <version>1.1.9-ALPHA</version>
+    <version>0.1.0</version>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
@@ -24,21 +24,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.16</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.12</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>2.0.16</version>
-        </dependency>
-        <dependency>
-            <groupId>nl.jessenagel.jhighs</groupId>
+            <groupId>nl.jessenagel.optimization</groupId>
             <artifactId>jhighs</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This pull request includes updates to dependency management and workflow configurations to align with the new versioning and group ID changes for the `jhighs` library. The most significant changes involve updating the version and group ID of `jhighs`, removing outdated logging dependencies, and refining Maven configurations.

### Dependency Updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the `jhighs` dependency to use version `0.1.0` and changed its group ID to `nl.jessenagel.optimization`. Removed outdated logging dependencies (`log4j`, `slf4j-log4j12`) and added a `scope` of `provided` to the `slf4j-api` dependency. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R27-R32)

### Workflow Configuration Updates:
* [`.github/workflows/checkpackaging.yml`](diffhunk://#diff-0d868dfe4de1a5a17799ffd219da9a0dc07770808ebba16d416a4903d58fb481L28-R40): Updated the download and installation steps for `jhighs` to use version `0.1.0` and the new group ID `nl.jessenagel.optimization`.
* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L33-R45): Updated the download and installation steps for `jhighs` to use version `0.1.0` and the new group ID `nl.jessenagel.optimization`.