### PR TITLE
Update checkpackaging.yml

### DIFF
--- a/.github/workflows/checkpackaging.yml
+++ b/.github/workflows/checkpackaging.yml
@@ -25,19 +25,19 @@ jobs:
           sudo apt-get install -y maven wget
       - name: Download and install jhighs
         run: |
-          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.0/jhighs-0.1.0.jar; then
+          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.1/jhighs-0.1.1.jar; then
             echo "Download successful"
-            ls -la jhighs-0.1.0.jar
+            ls -la jhighs-0.1.1.jar
           else
             echo "Download failed"
             exit 1
           fi
           
           mvn install:install-file \
-            -Dfile=jhighs-0.1.0.jar \
+            -Dfile=jhighs-0.1.1.jar \
             -DgroupId=nl.jessenagel.optimization \
             -DartifactId=jhighs \
-            -Dversion=0.1.0 \
+            -Dversion=0.1.1 \
             -Dpackaging=jar
 
       - name: Verify jhighs installation


### PR DESCRIPTION
This pull request updates the version of the `jhighs` dependency in the `.github/workflows/checkpackaging.yml` file to ensure the workflow uses the latest release.

Dependency version update:

* Updated the `jhighs` dependency from version `0.1.0` to `0.1.1` in the download URL, file name, and Maven installation parameters to use the latest release. (`[.github/workflows/checkpackaging.ymlL28-R40](diffhunk://#diff-0d868dfe4de1a5a17799ffd219da9a0dc07770808ebba16d416a4903d58fb481L28-R40)`)