### PR TITLE
Update maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,19 +30,19 @@ jobs:
           sudo apt-get install -y maven wget
       - name: Download and install jhighs
         run: |
-          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.0/jhighs-0.1.0.jar; then
+          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.1/jhighs-0.1.1.jar; then
             echo "Download successful"
-            ls -la jhighs-0.1.0.jar
+            ls -la jhighs-0.1.1.jar
           else
             echo "Download failed"
             exit 1
           fi
           
           mvn install:install-file \
-            -Dfile=jhighs-0.1.0.jar \
+            -Dfile=jhighs-0.1.1.jar \
             -DgroupId=nl.jessenagel.optimization \
             -DartifactId=jhighs \
-            -Dversion=0.1.0 \
+            -Dversion=0.1.1 \
             -Dpackaging=jar
 
       - name: Verify jhighs installation


### PR DESCRIPTION
This pull request updates the version of the `jhighs` library used in the Maven workflow to ensure compatibility with the latest release.

### Updates to Maven Workflow:
* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L33-R45): Updated the `jhighs` library from version `0.1.0` to `0.1.1` in the download URL, file name, and Maven installation configuration.