### PR TITLE
Update jhighs to version 0.1.2 in configuration files

### DIFF
--- a/.github/workflows/checkpackaging.yml
+++ b/.github/workflows/checkpackaging.yml
@@ -25,19 +25,19 @@ jobs:
           sudo apt-get install -y maven wget
       - name: Download and install jhighs
         run: |
-          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.1/jhighs-0.1.1.jar; then
+          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.2/jhighs-0.1.2.jar; then
             echo "Download successful"
-            ls -la jhighs-0.1.1.jar
+            ls -la jhighs-0.1.2.jar
           else
             echo "Download failed"
             exit 1
           fi
           
           mvn install:install-file \
-            -Dfile=jhighs-0.1.1.jar \
+            -Dfile=jhighs-0.1.2.jar \
             -DgroupId=nl.jessenagel.optimization \
             -DartifactId=jhighs \
-            -Dversion=0.1.1 \
+            -Dversion=0.1.2 \
             -Dpackaging=jar
 
       - name: Verify jhighs installation

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,19 +30,19 @@ jobs:
           sudo apt-get install -y maven wget
       - name: Download and install jhighs
         run: |
-          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.1/jhighs-0.1.1.jar; then
+          if wget https://github.com/jessenagel/JHiGHS/releases/download/v0.1.2/jhighs-0.1.2.jar; then
             echo "Download successful"
-            ls -la jhighs-0.1.1.jar
+            ls -la jhighs-0.1.2.jar
           else
             echo "Download failed"
             exit 1
           fi
           
           mvn install:install-file \
-            -Dfile=jhighs-0.1.1.jar \
+            -Dfile=jhighs-0.1.2.jar \
             -DgroupId=nl.jessenagel.optimization \
             -DartifactId=jhighs \
-            -Dversion=0.1.1 \
+            -Dversion=0.1.2 \
             -Dpackaging=jar
 
       - name: Verify jhighs installation

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>nl.jessenagel.optimization</groupId>
             <artifactId>jhighs</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This pull request updates the JHiGHS library version from `0.1.1` to `0.1.2` across the project, ensuring compatibility with the latest release. The changes affect workflow configuration files and the project's dependency management file.

### Workflow updates:
* [`.github/workflows/checkpackaging.yml`](diffhunk://#diff-0d868dfe4de1a5a17799ffd219da9a0dc07770808ebba16d416a4903d58fb481L28-R40): Updated the download URL, file name, and Maven installation parameters to use `jhighs-0.1.2.jar` instead of `jhighs-0.1.1.jar`.
* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L33-R45): Updated the download URL, file name, and Maven installation parameters to use `jhighs-0.1.2.jar` instead of `jhighs-0.1.1.jar`.

### Dependency management:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L32-R32): Updated the JHiGHS dependency version from `0.1.1` to `0.1.2`.